### PR TITLE
Change error pages to be closer to theme

### DIFF
--- a/app/assets/stylesheets/config/_bootstrap_variables.scss
+++ b/app/assets/stylesheets/config/_bootstrap_variables.scss
@@ -102,7 +102,7 @@ input.form-control {
 .btn {
   transition: all 0.3s ease;
   &:hover {
-    transform: scale(1.03, 1.03);
+    transform: scale(1.03); //only one argument needed if transformation is same in x and y direction
   }
 }
 

--- a/public/404.html
+++ b/public/404.html
@@ -3,16 +3,17 @@
 <head>
   <title>The page you were looking for doesn't exist (404)</title>
   <meta charset="utf-8" name="viewport" content="width=device-width,initial-scale=1">
-  <link href="https://fonts.googleapis.com/css?family=Share+Tech+Mono" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Quicksand" rel="stylesheet">
   <style>
 
   .rails-default-error-page {
-    color: #0FFF95;
+    color: rgba(220,220,220,0.8);
+    letter-spacing: .01em;
     margin: 0;
-    font-family: 'Share Tech Mono', 'monospace';
+    font-family: 'Quicksand', sans-serif;
     text-align: center;
     margin: 0;
-    text-decoration: none !important;
+    font-weight: lighter;
   }
 
   .rails-default-error-page div.banner {
@@ -26,43 +27,42 @@
     align-items: center;
     flex-direction: column;
     margin: 100px;
+    position: absolute;
+    left: 70px;
   }
 
   .rails-default-error-page .btn-error {
-    background: #2E996E;
-    border-radius: 0.1875rem;
-    text-transform: uppercase;
+    border-radius: 4px;
     color: #FFFFFF;
     height: 3.125rem;
     line-height: 3.125rem;
     width: 12.5rem;
     text-align: center;
-    letter-spacing: 0.125rem;
+    letter-spacing: .01em;
     font-size: 24px;
-
+    text-decoration: none;
+    transition: all 0.3s ease;
+    padding: 16px 28px;
+    border: 1px solid rgba(220,220,220,0.8);
+    margin-top: 30px;
   }
 
   .rails-default-error-page .btn-error:hover {
     background-color: #9B2E2E;
     cursor: pointer;
-  }
-
-  .btn-error:active {
-    background-color: #dd5754;
+    transform: scale(1.03);
   }
 
   </style>
-
 </head>
-
 <body class="rails-default-error-page">
   <!-- This file lives in public/404.html -->
-  <div class="banner" style="background-image: linear-gradient(-225deg, rgba(150,150,150,0.6) 0%, rgba(36,36,36,0.6) 50%), url('https://res.cloudinary.com/dcjfhbk0f/image/upload/v1544095233/frank-busch-731207-unsplash.jpg');">
+  <div class="banner" style="background-image: linear-gradient(-225deg, rgba(175,175,175,0.6) 0%, rgba(36,36,36,0.6) 50%), url('https://res.cloudinary.com/dcjfhbk0f/image/upload/v1544095233/frank-busch-731207-unsplash.jpg');">
   <div class="banner-content">
     <div class="warning">
-      <img src="https://res.cloudinary.com/dcjfhbk0f/image/upload/v1544104692/404.png" alt="404">
+      <h1>404</h1>
     </div>
-    <h1>The page you were looking for doesn't exist.</h1>
+    <h2>Hope that wasn't the one that got away . . .</h2>
     <h3>You may have mistyped the address or the page may have moved.</h3>
     <div class="btn-container">
       <a href="/experiences" class="btn-error">Return to Dates</a>

--- a/public/500.html
+++ b/public/500.html
@@ -2,18 +2,18 @@
 <html>
 <head>
   <title>We're sorry, but something went wrong (500)</title>
-  <meta name="viewport" content="width=device-width,initial-scale=1">
-  <link href="https://fonts.googleapis.com/css?family=VT323" rel="stylesheet">
-
+  <meta charset="utf-8" name="viewport" content="width=device-width,initial-scale=1">
+  <link href="https://fonts.googleapis.com/css?family=Quicksand" rel="stylesheet">
   <style>
 
   .rails-default-error-page {
-    color: #0FFF95;
+    color: rgba(220,220,220,0.8);
+    letter-spacing: .01em;
     margin: 0;
-    font-family: 'Share Tech Mono', 'monospace';
+    font-family: 'Quicksand', sans-serif;
     text-align: center;
     margin: 0;
-    text-decoration: none !important;
+    font-weight: lighter;
   }
 
   .rails-default-error-page div.banner {
@@ -27,40 +27,40 @@
     align-items: center;
     flex-direction: column;
     margin: 100px;
+    position: absolute;
+    top: 70px;
   }
 
   .rails-default-error-page .btn-error {
-    background: #2E996E;
-    border-radius: 0.1875rem;
-    text-transform: uppercase;
+    border-radius: 4px;
     color: #FFFFFF;
     height: 3.125rem;
     line-height: 3.125rem;
     width: 12.5rem;
     text-align: center;
-    letter-spacing: 0.125rem;
+    letter-spacing: .01em;
     font-size: 24px;
-
+    text-decoration: none;
+    transition: all 0.3s ease;
+    padding: 16px 28px;
+    border: 1px solid rgba(220,220,220,0.8);
+    margin-top: 30px;
   }
 
   .rails-default-error-page .btn-error:hover {
     background-color: #9B2E2E;
     cursor: pointer;
-  }
-
-  .btn-error:active {
-    background-color: #dd5754;
+    transform: scale(1.03);
   }
 
   </style>
 </head>
-
 <body class="rails-default-error-page">
   <!-- This file lives in public/500.html -->
-  <div class="banner" style="background-image: linear-gradient(-225deg, rgba(150,150,150,0.6) 0%, rgba(36,36,36,0.6) 50%), url('https://res.cloudinary.com/dcjfhbk0f/image/upload/v1544095213/aquarium-child-close-up-731141.jpg');">
+  <div class="banner" style="background-image: linear-gradient(-225deg, rgba(175,175,175,0.6) 0%, rgba(36,36,36,0.6) 50%), url('https://res.cloudinary.com/dcjfhbk0f/image/upload/v1544095213/aquarium-child-close-up-731141.jpg');">
   <div class="banner-content">
     <div class="warning">
-      <img src="https://res.cloudinary.com/dcjfhbk0f/image/upload/v1544104692/500.png" alt="500">
+      <h1>500</h1>
     </div>
     <h1>We're sorry, but something went wrong</h1>
     <h3>There is an error in our system.</h3>


### PR DESCRIPTION
Hey guys, I know that we've got such an awesome backend that no one will ever see the error pages ;) 
But here they are. I was wondering if anyone could help me with the following issues I had:
1) I used a Google font because I couldn't figure out how to get Gilroy in the page. I may have mentioned this, but because of where the error pages are located (the public folder), each needs to have its own styling in the HTML. So how would I do this? Is it an import, or what?
2) Transform on the hover state. I could get some of the hovering to work (it changes color), but I wanted to do the scaling. Couldn't get it to work; not sure why.
Thank you! 
@sensotape I hope these are more in line with our general theme as you had noted ;) 